### PR TITLE
fix(include): Add extern to global variables

### DIFF
--- a/include/esp_wpa.h
+++ b/include/esp_wpa.h
@@ -42,9 +42,9 @@ extern "C" {
   * @{
   */
 /* Crypto callback functions */
-const wpa_crypto_funcs_t g_wifi_default_wpa_crypto_funcs;
+extern const wpa_crypto_funcs_t g_wifi_default_wpa_crypto_funcs;
 /* Mesh crypto callback functions */
-const mesh_crypto_funcs_t g_wifi_default_mesh_crypto_funcs;
+extern const mesh_crypto_funcs_t g_wifi_default_mesh_crypto_funcs;
 
 /**
   * @brief     Supplicant initialization


### PR DESCRIPTION
to avoid the multiple definition link error
