### PR TITLE
xtensa/esp32: Fix esp_wpa.h global variable declaring error

### DIFF
--- a/include/esp_wpa.h
+++ b/include/esp_wpa.h
@@ -42,9 +42,9 @@ extern "C" {
   * @{
   */
 /* Crypto callback functions */
-const wpa_crypto_funcs_t g_wifi_default_wpa_crypto_funcs;
+extern const wpa_crypto_funcs_t g_wifi_default_wpa_crypto_funcs;
 /* Mesh crypto callback functions */
-const mesh_crypto_funcs_t g_wifi_default_mesh_crypto_funcs;
+extern const mesh_crypto_funcs_t g_wifi_default_mesh_crypto_funcs;
 
 /**
   * @brief     Supplicant initialization


### PR DESCRIPTION
Fix esp_wpa.h global variable declaring error.